### PR TITLE
Bug Fix: Resolves #17, jtagCommand() generates IndexError if drReadOhList is nonsequential

### DIFF
--- a/python/reg_interface/common/jtag.py
+++ b/python/reg_interface/common/jtag.py
@@ -164,7 +164,7 @@ def jtagCommand(restoreIdle, ir, irLen, dr, drLen, drReadOhList):
 
     #raw_input("Press any key to read TDI...")
 
-    readValues = []
+    readValues = {}
 
     if drReadOhList == False:
         return readValues
@@ -198,7 +198,7 @@ def jtagCommand(restoreIdle, ir, irLen, dr, drLen, drReadOhList):
             debug('tdi = ' + hex(tdi))
 
         readValue = (tdi >> readIdx) & (0xffffffffffffffffffffffffffffffff >> (128  - drLen))
-        readValues.append(readValue)
+        readValues[i] = readValue
         debug('Read pos = ' + str(readIdx))
         debug('Read = ' + hex(readValue))
     return readValues


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This should resolve issue #17.

Related too: https://github.com/cms-gem-daq-project/xhal/issues/75

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Since `jtagCommand()` returns a list if `drReadOhList` is nonsequential the indices of of the return of `jtagCommand()` will not match the elements in the input `drReadOhList` and generate an `IndexError`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With one OH, link 0:

```
$ sca.py eagle63 0x1 sysmon
...
...
=== OH #0 ===Core temp = -273.15, voltage #1 = 0.298828125, voltage #2 = 0.298828125 

=== OH #0 ===Core temp = 34.9440917969, voltage #1 = 1.0224609375, voltage #2 = 2.4609375 
```

With one OH, link 1:

```
$ sca.py eagle63 0x2 sysmon
...
...
=== OH #1 ===Core temp = 31.9911132813, voltage #1 = 1.0341796875, voltage #2 = 2.5546875 

=== OH #1 ===Core temp = 31.9911132813, voltage #1 = 1.0341796875, voltage #2 = 2.5546875 
```

With two OH's, links 0 & 1:

```
$ sca.py eagle63 0x3 sysmon
...
...
=== OH #0 ===Core temp = 34.4519287109, voltage #1 = 1.0224609375, voltage #2 = 2.4609375 

=== OH #1 ===Core temp = 31.9911132813, voltage #1 = 1.0341796875, voltage #2 = 2.5546875 

=== OH #0 ===Core temp = 34.4519287109, voltage #1 = 1.0224609375, voltage #2 = 2.4609375 

=== OH #1 ===Core temp = 31.9911132813, voltage #1 = 1.0341796875, voltage #2 = 2.5546875
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
