### PR TITLE
pick up version number from tag

### DIFF
--- a/python/reg_generator/Makefile
+++ b/python/reg_generator/Makefile
@@ -20,9 +20,9 @@ ScriptDir    := pkg/$(Namespace)/scripts
 PythonModules = ["$(Namespace).$(ShortPackage)"]
 $(info PythonModules=${PythonModules})
 
-REG_GENERATOR_VER_MAJOR=1
-REG_GENERATOR_VER_MINOR=0
-REG_GENERATOR_VER_PATCH=0
+REG_GENERATOR_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+REG_GENERATOR_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+REG_GENERATOR_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfPythonDefs.mk

--- a/python/reg_interface/Makefile
+++ b/python/reg_interface/Makefile
@@ -20,9 +20,9 @@ ScriptDir    := pkg/$(Namespace)/scripts
 PythonModules = ["$(Namespace).$(ShortPackage)"]
 $(info PythonModules=${PythonModules})
 
-REG_INTERFACE_VER_MAJOR=1
-REG_INTERFACE_VER_MINOR=0
-REG_INTERFACE_VER_PATCH=0
+REG_INTERFACE_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+REG_INTERFACE_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+REG_INTERFACE_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfPythonDefs.mk

--- a/rwreg/arm/Makefile
+++ b/rwreg/arm/Makefile
@@ -17,8 +17,8 @@ RWREG_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{spli
 RWREG_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
 RWREG_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
-include $(BUILD_HOME)/$(Project)/config/mfZynq.mk
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
+include $(BUILD_HOME)/$(Project)/config/mfZynq.mk
 include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
 
 IncludeDirs= ${BUILD_HOME}/${Project}/${Package}/${Arch}/include

--- a/rwreg/arm/Makefile
+++ b/rwreg/arm/Makefile
@@ -13,9 +13,9 @@ PackageDir   := pkg/$(ShortPackage)
 Arch         := arm
 Packager     := Mykhailo Dalchenko
 
-RWREG_VER_MAJOR=1
-RWREG_VER_MINOR=0
-RWREG_VER_PATCH=0
+RWREG_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+RWREG_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+RWREG_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 include $(BUILD_HOME)/$(Project)/config/mfZynq.mk
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk

--- a/rwreg/x86_64/Makefile
+++ b/rwreg/x86_64/Makefile
@@ -10,9 +10,9 @@ PackageDir   := pkg/$(ShortPackage)
 Arch         := x86_64
 Packager     := Mykhailo Dalchenko
 
-RWREG_VER_MAJOR=1
-RWREG_VER_MINOR=0
-RWREG_VER_PATCH=0
+RWREG_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+RWREG_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+RWREG_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk

--- a/rwreg/x86_64/Makefile
+++ b/rwreg/x86_64/Makefile
@@ -17,7 +17,6 @@ RWREG_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{spli
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
 
-CC=g++
 CCFLAGS=-O0 -g3 -fno-inline -Wall -fPIC -pthread -m64
 
 LDFLAGS=-shared


### PR DESCRIPTION
## Motivation and Context
Makes sure versions come from the tag and number of commits since last tag.
Allows uniformly sequential builds to be built.

## How Has This Been Tested?
Tested `make rpm` with a final, preliminary, and untagged commit
