### PR TITLE
Bug Fix #21: sca.py no longer relies on sys.argv to obtain inputs 

### DIFF
--- a/python/reg_interface/common/gpio.py
+++ b/python/reg_interface/common/gpio.py
@@ -1,7 +1,10 @@
 from reg_xml_parser import getNode
 from reg_base_ops import writeReg
+from print_utils import *
 from bit_utils import hex
 from sca_common_utils import getOHlist, sendScaCommand
+from time import sleep
+
 def set_direction(ohMask, directionMask):
     subheading('Disabling monitoring')
     writeReg(getNode('GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF'), 0xffffffff)

--- a/python/reg_interface/common/reg_xml_parser.py
+++ b/python/reg_interface/common/reg_xml_parser.py
@@ -281,7 +281,6 @@ def parseInt(s):
     else:
         return int(string)
 
-
 def substituteVars(string, vars):
     """
     

--- a/python/reg_interface/scripts/sca.py
+++ b/python/reg_interface/scripts/sca.py
@@ -51,22 +51,19 @@ def fpgaProgram(args):
         return
     
     import os
-    if ((args.fwFileBit is not None) and ("bit" not in args.fwFileBit)):
-        print("you must supply a *.bit file to '--fwFileBit'")
-        exit(os.EX_USAGE)
-    if ((args.fwFileMCS is not None) and ("mcs" not in args.fwFileMCS)):
-        print("you must supply a *.mcs file to '--fwFileMCS'")
+    if ((args.fwFile is None):
+        print("you must supply either a *.bit or a *.mcs file to '--fwFile'")
         exit(os.EX_USAGE)
 
-    if args.fwFileBit is not None:
+    if "bit" in args.fwFile:
         ftype = "bit"
-        filename = args.fwFileBit
-    elif args.fwFileMCS is not None:
+        filename = args.fwFile
+    elif "mcs" in args.fwFile:
         ftype = "mcs"
-        filename = args.fwFileMCS
+        filename = args.fwFile
     else:
-        printRed('Usage: sca.py local <ohMask> program-fpga --fwFileBit=<filename>')
-        printRed('if your firmware file is a *.msc file use the --fwFileMCS argument')
+        printRed('Usage: sca.py local <ohMask> program-fpga --fwFile=<filename>')
+        print("you must supply either a *.bit or a *.mcs file to '--fwFile'")
         return
     
     from reg_utils.reg_interface.arm.program_fpga import program_fpga
@@ -162,10 +159,8 @@ if __name__ == '__main__':
     # Create subparser for programming the fpga
     parser_programFPGA = subparserCmds.add_parser("program-fpga", help="Program OH FPGA with a bitfile or an MCS file")
     fpgaFileGroup = parser_programFPGA.add_mutually_exclusive_group()
-    fpgaFileGroup.add_argument("--fwFileBit", type=str, dest="fwFileBit", default=None,
-                      help="firmware bit file to program fpga with", metavar="fwFileBit")
-    fpgaFileGroup.add_argument("--fwFileMCS", type=str, dest="fwFileMCS", default=None,
-                      help="firmware mcs file to program fpga with", metavar="fwFileBit")
+    fpgaFileGroup.add_argument("--fwFile", type=str, dest="fwFile", required=True,
+                      help="firmware file to program fpga with, must end in either '*.bit' or '*.mcs'", metavar="fwFile")
     parser_programFPGA.set_defaults(func=fpgaProgram)
 
     # Create subparser for gpio-read-input

--- a/python/reg_interface/scripts/sca.py
+++ b/python/reg_interface/scripts/sca.py
@@ -11,16 +11,12 @@ from time import *
 import socket
 
 def compareFwFiles(args):
-    if ((args.fwFileBit is None) or (args.fwFileMCS is None)):
-        print("Usage: sca.py <cardName> <ohMask> compare-mcs-bit --fwFileMCS=<mcs_filename> --fwFileBit=<bit_filename>")
-        return
-
     import os
     if "bit" not in args.fwFileBit:
-        print("you must supply a *.bit file to '--fwFileBit'")
+        print("you must supply a *.bit file to 'fwFileBit'")
         exit(os.EX_USAGE)
     if "mcs" not in args.fwFileMCS:
-        print("you must supply a *.mcs file to '--fwFileMCS'")
+        print("you must supply a *.mcs file to 'fwFileMCS'")
         exit(os.EX_USAGE)
 
     from reg_utils.reg_interface.arm.program_fpga import compare_mcs_bit
@@ -51,10 +47,6 @@ def fpgaProgram(args):
         return
     
     import os
-    if ((args.fwFile is None):
-        print("you must supply either a *.bit or a *.mcs file to '--fwFile'")
-        exit(os.EX_USAGE)
-
     if "bit" in args.fwFile:
         ftype = "bit"
         filename = args.fwFile
@@ -62,8 +54,8 @@ def fpgaProgram(args):
         ftype = "mcs"
         filename = args.fwFile
     else:
-        printRed('Usage: sca.py local <ohMask> program-fpga --fwFile=<filename>')
-        print("you must supply either a *.bit or a *.mcs file to '--fwFile'")
+        printRed('Usage: sca.py local <ohMask> program-fpga fwFile=<filename>')
+        print("you must supply either a *.bit or a *.mcs file to 'fwFile'")
         return
     
     from reg_utils.reg_interface.arm.program_fpga import program_fpga
@@ -77,21 +69,11 @@ def gpioRead(args):
 
 def gpioSetDirection(args):
     scaInit(args)
-
-    if args.gpioValue is None:
-        print('Usage: sca.py <cardName> <ohMask> gpio-set-direction --gpioVale=<direction-mask>')
-        print('direction-mask is a 32 bit number where each bit represents a GPIO channel -- if a given bit is high it means that this GPIO channel will be set to OUTPUT mode, and otherwise it will be set to INPUT mode')
-        return
     gpio.set_direction(args.ohMask,args.gpioValue)
     return
 
 def gpioSetOutput(args):
     scaInit(args)
-
-    if args.gpioValue is None:
-        print('Usage: sca.py <cardName> <ohMask> gpio-set-output --gpioValue=<output-data>')
-        print('output-data is a 32 bit number representing the 32 GPIO channels state')
-        return
     gpio.set_output(args.ohMask,args.gpioValue)
 
 def scaInit(args):
@@ -138,10 +120,8 @@ if __name__ == '__main__':
 
     # Create subparser for compare-mcs-bit
     parser_compareFwFiles = subparserCmds.add_parser("compare-mcs-bit", help="compares a *.mcs with a *.bit file to check if the firmware is the same")
-    parser_compareFwFiles.add_argument("--fwFileBit",type=str, dest="fwFileBit", required=True,
-            help="firmware bit file to be used in the comparison", metavar="fwFileBit")
-    parser_compareFwFiles.add_argument("--fwFileMCS",type=str, dest="fwFileMCS", required=True,
-            help="firmware mcs file to be used in the comparison", metavar="fwFileMCS")
+    parser_compareFwFiles.add_argument("fwFileMCS",type=str, help="firmware mcs file to be used in the comparison", metavar="fwFileMCS")
+    parser_compareFwFiles.add_argument("fwFileBit",type=str, help="firmware bit file to be used in the comparison", metavar="fwFileBit")
     parser_compareFwFiles.set_defaults(func=compareFwFiles)
 
     # Create subparser for fpga hard reset 
@@ -158,9 +138,7 @@ if __name__ == '__main__':
 
     # Create subparser for programming the fpga
     parser_programFPGA = subparserCmds.add_parser("program-fpga", help="Program OH FPGA with a bitfile or an MCS file")
-    fpgaFileGroup = parser_programFPGA.add_mutually_exclusive_group()
-    fpgaFileGroup.add_argument("--fwFile", type=str, dest="fwFile", required=True,
-                      help="firmware file to program fpga with, must end in either '*.bit' or '*.mcs'", metavar="fwFile")
+    parser_programFPGA.add_argument("fwFile", type=str, help="firmware file to program fpga with, must end in either '*.bit' or '*.mcs'", metavar="fwFile")
     parser_programFPGA.set_defaults(func=fpgaProgram)
 
     # Create subparser for gpio-read-input
@@ -170,14 +148,14 @@ if __name__ == '__main__':
     # Create subparser for gpio-set-direction
     # Default corresponds to setting SCA output direction on OHv3c
     parser_setGPIODirection = subparserCmds.add_parser("gpio-set-direction", help="Set the GPIO Direction Mask")
-    parser_setGPIODirection.add_argument("--gpioValue", type=parseInt, dest="gpioValue", default=0x0fffff8f, metavar="gpioValue",
+    parser_setGPIODirection.add_argument("gpioValue", type=parseInt, default=0x0fffff8f, metavar="gpioValue",
             help="32 bit number where each bit represents a GPIO channel.  If a given bit is high it means that this GPIO channel will be set to OUTPUT mode, and otherwise it will be set to INPUT mode")
     parser_setGPIODirection.set_defaults(func=gpioSetDirection)
    
     # Create subparser for gpio-set-output
     # Default corresponds to setting SCA output value on the OHv3c
     parser_setGPIOOutput = subparserCmds.add_parser("gpio-set-output", help="Set the GPIO output values")
-    parser_setGPIOOutput.add_argument("--gpioValue", type=parseInt, dest="gpioValue", default=0xf00000f0, metavar="gpioValue",
+    parser_setGPIOOutput.add_argument("gpioValue", type=parseInt, default=0xf00000f0, metavar="gpioValue",
             help="32 bit number where each bit represents the 32 GPIO channels state")
     parser_setGPIOOutput.set_defaults(func=gpioSetOutput)
 

--- a/python/reg_interface/scripts/sca.py
+++ b/python/reg_interface/scripts/sca.py
@@ -108,36 +108,24 @@ if __name__ == '__main__':
             #'test1',
             #'test2',
             ]
-
-    strSupCmds = "[ %s"%supportedCmds[0]
-    for idx in range(1,len(supportedCmds)):
-        strSupCmds = "%s, %s"%(strSupCmds,supportedCmds[idx])
-    strSupCmds = "%s ]"%strSupCmds
-
     from optparse import OptionParser
-    parser = OptionParser()
-    parser.add_option("--cardName", type="string", dest="cardName", default=None,
+    import argparse
+    parser = argparse.ArgumentParser(description='Arguments to supply to sca.py')
+    parser.add_argument("--cardName", type="string", dest="cardName", default=None, required=True,
                       help="hostname of the AMC you are connecting too, e.g. 'eagle64'; if running on an AMC use 'local' instead", metavar="cardName")
-    parser.add_option("--cmd", type="string", dest="cmd", default=None,
-                      help="command to be executed from list: %s"%strSupCmds, metavar="cardName")
-    parser.add_option("--fwFileBit", type="string", dest="fwFileBit", default=None,
+    parser.add_argument("--cmd", type="string", dest="cmd", default=None, required=True, choices=supportedCmds,
+                      help="command to be executed", metavar="cardName")
+    parser.add_argument("--fwFileBit", type="string", dest="fwFileBit", default=None,
                       help="firmware bit file to be used with either 'program-fpga' or 'compare-mcs-bit' commands (e.g. --cmd='program-fpga')", metavar="fwFileBit")
-    parser.add_option("--fwFileMCS", type="string", dest="fwFileMCS", default=None,
+    parser.add_argument("--fwFileMCS", type="string", dest="fwFileMCS", default=None,
                       help="firmware mcs file to be used with either 'program-fpga' or 'compare-mcs-bit' commands (e.g. --cmd='program-fpga')", metavar="fwFileBit")
-    parser.add_option("--gpioValue", type="int", dest="gpioValue", default=None,
+    parser.add_argument("--gpioValue", type="int", dest="gpioValue", default=None,
                       help="gpio value to write with either 'gpio-set-direction' or 'gpio-set-output' commands (e.g. --cmd='gpio-set-direction')", metavar="gpioValue")
-    parser.add_option("--ohMask", type="int", dest="ohMask", default=0x1,
+    parser.add_argument("--ohMask", type="int", dest="ohMask", default=0x1,
                       help="ohMask to apply, a 1 in the n^th bit indicates the n^th OH should be considered", metavar="ohMask")
     (options, args) = parser.parse_args()
 
     import os
-    if options.cardName is None:
-        print("you must specify the --cardName argument")
-        exit(os.EX_USAGE)
-    if ((options.cmd is None) or (options.cmd not in supportedCmds)):
-        print("you must specify a command; supported commands are from the list:")
-        print(supportedCmds)
-        exit(os.EX_USAGE)
     if ((options.fwFileBit is not None) and ("bit" not in options.fwFileBit)):
         print("you must supply a *.bit file to '--fwFileBit'")
         exit(os.EX_USAGE)

--- a/python/reg_interface/scripts/sca.py
+++ b/python/reg_interface/scripts/sca.py
@@ -45,7 +45,7 @@ def main(cardName, instructions, ohMask, fwFileBit=None, fwFileMCS=None, gpioVal
     elif instructions == 'program-fpga':
         hostname = socket.gethostname()
         if 'eagle' in hostname:
-            from reg_interface.arm.program_fpga import program_fpga
+            from reg_utils.reg_interface.arm.program_fpga import program_fpga
         else:
             printRed("This method should only be called from the card!!")
             return
@@ -63,16 +63,17 @@ def main(cardName, instructions, ohMask, fwFileBit=None, fwFileMCS=None, gpioVal
 
         program_fpga(ohMask,ftype,filename)
 
-    elif instructions == 'test1':
-        test1()
+    #elif instructions == 'test1':
+    #    test1()
         
-    elif instructions == 'test2':
-        test2()
+    #elif instructions == 'test2':
+    #    test2()
 
     elif instructions == 'compare-mcs-bit':
         if ((fwFileBit is None) or (fwFileMCS is None)):
             print("Usage: sca.py --cardName=<cardName> --cmd='compare-mcs-bit' --fwFileMCS=<mcs_filename> --fwFileBit=<bit_filename>")
             return
+        from reg_utils.reg_interface.arm.program_fpga import compare_mcs_bit
         compare_mcs_bit(fwFileMCS, fwFileBit)
 
     elif instructions == 'gpio-set-direction':
@@ -100,13 +101,12 @@ if __name__ == '__main__':
             'fpga-id',
             'gpio-read-input',
             'gpio-set-direction',
-            'gpio-set-output'
+            'gpio-set-output',
             'program-fpga',
             'r',
             'sysmon',
-            'test1',
-            'test2',
-
+            #'test1',
+            #'test2',
             ]
 
     strSupCmds = "[ %s"%supportedCmds[0]
@@ -134,11 +134,17 @@ if __name__ == '__main__':
     if options.cardName is None:
         print("you must specify the --cardName argument")
         exit(os.EX_USAGE)
-    if options.cmd is None:
+    if ((options.cmd is None) or (options.cmd not in supportedCmds)):
         print("you must specify a command; supported commands are from the list:")
         print(supportedCmds)
         exit(os.EX_USAGE)
-        
+    if ((options.fwFileBit is not None) and ("bit" not in options.fwFileBit)):
+        print("you must supply a *.bit file to '--fwFileBit'")
+        exit(os.EX_USAGE)
+    if ((options.fwFileMCS is not None) and ("mcs" not in options.fwFileMCS)):
+        print("you must supply a *.mcs file to '--fwFileMCS'")
+        exit(os.EX_USAGE)
+
     main(
             cardName=options.cardName,
             instructions=options.cmd,

--- a/python/reg_interface/scripts/sca.py
+++ b/python/reg_interface/scripts/sca.py
@@ -141,7 +141,7 @@ if __name__ == '__main__':
     parser_compareFwFiles.add_argument("--fwFileBit",type=str, dest="fwFileBit", required=True,
             help="firmware bit file to be used in the comparison", metavar="fwFileBit")
     parser_compareFwFiles.add_argument("--fwFileMCS",type=str, dest="fwFileMCS", required=True,
-            help="firmware bit file to be used in the comparison", metavar="fwFileMCS")
+            help="firmware mcs file to be used in the comparison", metavar="fwFileMCS")
     parser_compareFwFiles.set_defaults(func=compareFwFiles)
 
     # Create subparser for fpga hard reset 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Exhibited several bugs with `sca.py` while testing v3 electronics.  All of which seem to relate to lack of care with argument order of `sys.argv`.  To be more pythonic I've implemented an `argparser` object and have done extensive testing.

Previous positional arguments have been maintained.

Noted significant divergences between `sca.py` on the `texas` account of CTP7 and our use case.  This should be really frowned upon and active development on private area locations should be stopped.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Changes to `sca.py` over time have made the order of arguments challenging to keep up with and resulted in ambiguity.  This addresses #21 and other incidents in which the addition of the `<cardName>` has caused an index error.

Additionally several undocumented instructions are now necessary to configure the OHv3c (bad).  These are now documented. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
~~Extensively tested at [this elog post](http://cmsonline.cern.ch/cms-elog/1052291)~~
~~Extensively tested using `argparser` at [this elog post](http://cmsonline.cern.ch/cms-elog/1052999)~~
See [post](http://cmsonline.cern.ch/cms-elog/1053370)

New usage:

```
% sca.py -h
usage: sca.py [-h]
              cardName ohMask
              {compare-mcs-bit,h,hh,fpga-id,program-fpga,gpio-read-input,gpio-set-direction,gpio-set-output,r,sysmon}
              ...

Arguments to supply to sca.py

positional arguments:
  cardName              hostname of the AMC you are connecting too, e.g.
                        'eagle64'; if running on an AMC use 'local' instead
  ohMask                ohMask to apply, a 1 in the n^th bit indicates the
                        n^th OH should be considered
  {compare-mcs-bit,h,hh,fpga-id,program-fpga,gpio-read-input,gpio-set-direction,gpio-set-output,r,sysmon}
                        sca command help
    compare-mcs-bit     compares a *.mcs with a *.bit file to check if the
                        firmware is the same
    h                   FPGA hard reset will be done
    hh                  FPGA hard reset will be asserted and held
    fpga-id             FPGA ID will be read through JTAG
    program-fpga        Program OH FPGA with a bitfile or an MCS file
    gpio-read-input     Read GPIO settings of the SCA
    gpio-set-direction  Set the GPIO Direction Mask
    gpio-set-output     Set the GPIO output values
    r                   SCA reset will be done
    sysmon              Read FPGA sysmon data repeatedly

optional arguments:
  -h, --help            show this help message and exit
```

Additional option menus for `sub_commands`:

Comparing firmware files:
```
sca.py eagle60 0x2 compare-mcs-bit -h
usage: sca.py cardName ohMask compare-mcs-bit [-h] fwFileMCS fwFileBit

positional arguments:
  fwFileMCS   firmware mcs file to be used in the comparison
  fwFileBit   firmware bit file to be used in the comparison

optional arguments:
  -h, --help  show this help message and exit
```

Programming FPGA using JTAG via SCA:
```
% sca.py eagle60 0x2 program-fpga -h   
usage: sca.py cardName ohMask program-fpga [-h] fwFile

positional arguments:
  fwFile      firmware file to program fpga with, must end in either '*.bit'
              or '*.mcs'

optional arguments:
  -h, --help  show this help message and exit
```

Setting gpio direction:
```
% sca.py eagle60 0x2 gpio-set-direction -h
usage: sca.py cardName ohMask gpio-set-direction [-h] gpioValue

positional arguments:
  gpioValue   32 bit number where each bit represents a GPIO channel. If a
              given bit is high it means that this GPIO channel will be set to
              OUTPUT mode, and otherwise it will be set to INPUT mode

optional arguments:
  -h, --help  show this help message and exit
```

Setting gpio output:
```
% sca.py eagle60 0x2 gpio-set-output -h   
usage: sca.py cardName ohMask gpio-set-output [-h] gpioValue

positional arguments:
  gpioValue   32 bit number where each bit represents the 32 GPIO channels
              state

optional arguments:
  -h, --help  show this help message and exit
```

### Comparing FW Files
```
sca.py eagle60 2 compare-mcs-bit OH-20180320-3.1.1.B.mcs OH-20180320-3.1.1.B.bit
```

### Issuing Resets
```
sca.py eagle60 2 h
sca.py eagle60 2 hh
sca.py eagle60 2 r
```

### Reading FPGA-ID
```
sca.py eagle60 0x2 fpga-id 
```

### GPIO Commands

```
sca.py eagle60 0x2 gpio-read-input
sca.py eagle60 2 gpio-set-direction 0x0fffff8f
sca.py eagle60 2 gpio-set-output 0xf00000f0
```

### Programming FPGA
This is not yet testable since it requires changes to `setup_ctp7.sh` and migration of reg_utils to the actual card.  However the script correctly identifies that it should not be called from the DAQ machine with this command.

### Reading sysmon
```
sca.py eagle60 0x2 sysmon
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
