### PR TITLE
Bug Fix: NameError in gbt.py #23

### DIFF
--- a/python/reg_interface/scripts/gbt.py
+++ b/python/reg_interface/scripts/gbt.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 from reg_utils.reg_interface.arm.gbt_utils import programGBT
+from reg_utils.reg_interface.common.print_utils import printRed
 from time import *
 import array
 import struct
 import os
+import sys
+import socket
 
 if __name__ == '__main__':
     if len(sys.argv) < 4:
@@ -18,6 +21,13 @@ if __name__ == '__main__':
         gbtSelect = int(sys.argv[2])
         command = sys.argv[3]
     
+    hostname = socket.gethostname()
+    if 'eagle' in hostname:
+        pass
+    else:
+       printRed("This command should only be called from a CTP7!!!")
+       return
+        
     if ohSelect > 11:
         printRed("The given OH index (%d) is out of range (must be 0-11)" % ohSelect)
         exit(os.EX_USAGE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses #23.

Fixed missing `sys` import and now the user will no longer be able to call this method from the DAQ machine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
NameError generated due to missing import.  Also prevents being called from the DAQ machine.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
