### PR TITLE
Bug Fix for #25

### DIFF
--- a/python/reg_interface/scripts/sca.py
+++ b/python/reg_interface/scripts/sca.py
@@ -76,7 +76,7 @@ def gpioSetOutput(args):
     scaInit(args)
     gpio.set_output(args.ohMask,args.gpioValue)
 
-def scaInit(args):
+def scaInit(args, isReset=False):
     ohList = getOHlist(args.ohMask)
 
     parseXML()
@@ -91,7 +91,7 @@ def scaInit(args):
     heading("Hola, I'm SCA controller tester :)")
 
     if not checkStatus(ohList):
-        if not 'r' in instructions:
+        if not isReset:
             exit()
 
     writeReg(getNode('GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.LINK_ENABLE_MASK'), args.ohMask)
@@ -99,7 +99,7 @@ def scaInit(args):
     return ohList
 
 def scaReset(args):
-    ohList = scaInit(args)
+    ohList = scaInit(args=args,isReset=True)
     sca_reset(ohList)
     return
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses: https://github.com/cms-gem-daq-project/reg_utils/issues/25

Fixed a bug in `scaInit()` that prevented an SCA reset from being sent if no communication existed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
#25 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
http://cmsonline.cern.ch/cms-elog/1054697

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
