### PR TITLE
New Feature: SCA reset follows enable mask if present

### DIFF
--- a/python/reg_interface/common/sca_utils.py
+++ b/python/reg_interface/common/sca_utils.py
@@ -19,12 +19,14 @@ def sca_reset(ohMask):
     if scaResetMaskNode is not None:
         origMask = readReg(scaResetMaskNode)
         writeReg(scaResetMaskNode, ohMask)
+    else:
+        print("No SCA_RESET_ENABLE_MASK register detected, reset will be applied to all links")
 
     writeReg(getNode('GEM_AMC.SLOW_CONTROL.SCA.CTRL.MODULE_RESET'), 0x1)
 
     # Reset the sca reset mask if it exists
     if scaResetMaskNode is not None:
-        writeReg(scaResetMaskNode, origMask)
+        writeReg(scaResetMaskNode, int(origMask,16))
 
     checkStatus(getOHlist(ohMask))
 

--- a/python/reg_interface/common/sca_utils.py
+++ b/python/reg_interface/common/sca_utils.py
@@ -11,10 +11,22 @@ import array
 import struct
 import socket
 
-def sca_reset(ohList):
+def sca_reset(ohMask):
     subheading('Reseting the SCA')
+
+    # Set the sca reset mask if it exists
+    scaResetMaskNode = getNode('GEM_AMC.SLOW_CONTROL.SCA.CTRL.SCA_RESET_ENABLE_MASK')
+    if scaResetMaskNode is not None:
+        origMask = readReg(scaResetMaskNode)
+        writeReg(scaResetMaskNode, ohMask)
+
     writeReg(getNode('GEM_AMC.SLOW_CONTROL.SCA.CTRL.MODULE_RESET'), 0x1)
-    checkStatus(ohList)
+
+    # Reset the sca reset mask if it exists
+    if scaResetMaskNode is not None:
+        writeReg(scaResetMaskNode, origMask)
+
+    checkStatus(getOHlist(ohMask))
 
 def fpga_single_hard_reset():
     subheading('Issuing FPGA Hard Reset')

--- a/python/reg_interface/scripts/gbt.py
+++ b/python/reg_interface/scripts/gbt.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
         pass
     else:
        printRed("This command should only be called from a CTP7!!!")
-       return
+       exit(os.EX_USAGE)
         
     if ohSelect > 11:
         printRed("The given OH index (%d) is out of range (must be 0-11)" % ohSelect)

--- a/python/reg_interface/scripts/sca.py
+++ b/python/reg_interface/scripts/sca.py
@@ -99,8 +99,8 @@ def scaInit(args, isReset=False):
     return ohList
 
 def scaReset(args):
-    ohList = scaInit(args=args,isReset=True)
-    sca_reset(ohList)
+    scaInit(args=args,isReset=True)
+    sca_reset(args.ohMask)
     return
 
 def sysmon(args):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In [CTP7 firmware 3.5.3](https://github.com/evka85/GEM_AMC/releases/tag/v3.5.3) and higher the sca block comes with a reset enable register.

This enables the `sca.py` tool to only apply the SCA reset to the OH's defined in `ohMask`.

The `sca_reset()` function will now check if the node for the sca reset enable mask exists.  If it does it will read the existing mask, apply the provided `ohMask`, issue the sca reset, and then revert the sca reset enable mask to the original value.

If the node does not exist (e.g. CTP7 firmware versions pre 3.5.3) the current behavior will be maintained.

Change is backwards compatible. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
In v3 electronics the CTP7 firmware now enables the sca reset to be applied to a specific set of links rather than all links.  This is of interest to test stands with multiple OH's connected (gem sustained operation, QC8, 904 coffin) as an sca reset will:

- Cause a loss of FW on the FPGA (causing a reset of all VFAT3s for OHv3b or OHv3a), 
- Cause a reset of the VFAT3's for OHv3c.

If the SCA reset enable mask is not applied this will reset all links and require the operator to painfully recover all links.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing on a FW release that does not have the enable mask: http://cmsonline.cern.ch/cms-elog/1056673
Testing on a FW release that does have the enable mask: http://cmsonline.cern.ch/cms-elog/1056677

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
