### PR TITLE
add a script to read a register multiple times

### DIFF
--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -5,9 +5,6 @@ from reg_utils.reg_interface.common.print_utils import printRed
 from reg_utils.reg_interface.common.jtag import initJtagRegAddrs
 from reg_utils.reg_interface.common.reg_base_ops import *
 
-#from rw_reg import *
-#from mcs import *
-
 import time
 import socket
 

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -1,24 +1,21 @@
 #!/usr/bin/env python
 
-from reg_utils.reg_interface.common.reg_xml_parser import getNode, parseXML
-from reg_utils.reg_interface.common.print_utils import printRed
-from reg_utils.reg_interface.common.jtag import initJtagRegAddrs
-from reg_utils.reg_interface.common.reg_base_ops import *
-
-import time
-import socket
-
-import argparse
-
 if __name__ == '__main__':
 
+    from reg_utils.reg_interface.common.reg_xml_parser import getNode, parseXML
+    from reg_utils.reg_interface.common.reg_base_ops import *
+    
+    import time
+    import socket
+    import argparse
+    
     parser = argparse.ArgumentParser(description='Arguments to supply to repeated_reg_read.py')
 
-    parser.add_argument('reg_name', metavar='reg_name', type=str,help='Name of the register to read')
-    parser.add_argument('nreads', metavar='nreads', type=str,help='Number of reads')
-    parser.add_argument('sleeptime', metavar='sleeptime', type=str,help='Amount of time to sleep in microseconds')
-    parser.add_argument('-f','--filename', metavar='filename', type=str, help="Filename to which output information is written", default="repeated_reg_read.txt")
-    parser.add_argument('--card', metavar='card', type=str,help='CTP7 hostname (has no effect if you are running on a hostname that starts with eagle)',default="eagle26")
+    parser.add_argument('reg_name',metavar='reg_name',type=str,help='Name of the register to read')
+    parser.add_argument('nreads',metavar='nreads',type=int,help='Number of reads')
+    parser.add_argument('sleeptime',metavar='sleeptime',type=float,help='Amount of time to sleep in microseconds')
+    parser.add_argument('-f','--filename',metavar='filename',type=str,help="Filename to which output information is written",default="repeated_reg_read.txt")
+    parser.add_argument('--card',metavar='card',type=str,help='CTP7 hostname (has no effect if you are running on a hostname that starts with eagle)',default="eagle26")
 
     args = parser.parse_args()
 
@@ -37,7 +34,7 @@ if __name__ == '__main__':
 
     writeReg(getNode("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET"),0x1)   
 
-    time.sleep(float(args.sleeptime)/float(1000000))
+    time.sleep(args.sleeptime/1000000.)
     
     crc_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT").real_address)
     packet_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT").real_address)
@@ -47,29 +44,27 @@ if __name__ == '__main__':
     transaction_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT").real_address)
     link_reset_before = readAddress(getNode("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET").real_address)
 
-    f.write( "|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |\n")
-    print( "|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |")
-    
-    f.write("|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |\n")
-    print("|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |")
+    outstring="|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |"
+    f.write(outstring)
+    f.write('\n')
+    print(outstring)
 
-    f.write("| before | {0}  | {1} | {2} | {3} | {4} | {5} |\n".format(
+    outstring="|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |"
+    f.write(outstring)
+    f.write('\n')
+    print(outstring)
+
+    outstring="| before | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
             crc_error_cnt_before,
             packet_error_cnt_before,
             bitstuffing_error_cnt_before,
             timeout_error_cnt_before,
             axi_strobe_error_cnt_before,
             transaction_cnt_before
-         ))
-
-    print("| before | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
-            crc_error_cnt_before,
-            packet_error_cnt_before,
-            bitstuffing_error_cnt_before,
-            timeout_error_cnt_before,
-            axi_strobe_error_cnt_before,
-            transaction_cnt_before
-         ))
+         )
+    f.write(outstring)
+    f.write('\n')
+    print(outstring)
 
     node = getNode(args.reg_name)
 
@@ -83,7 +78,7 @@ if __name__ == '__main__':
         else:
             register_values[value] = 1
         
-        time.sleep(float(args.sleeptime)/float(1000000))
+        time.sleep(args.sleeptime/1000000.)
 
     crc_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT").real_address)
     packet_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT").real_address)
@@ -92,48 +87,38 @@ if __name__ == '__main__':
     axi_strobe_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT").real_address)
     transaction_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT").real_address)
 
-    crc_error_cnt_delta = str(int(crc_error_cnt_after,16) - int(crc_error_cnt_before,16))
-    packet_error_cnt_delta = str(int(packet_error_cnt_after,16) - int(packet_error_cnt_before,16))
-    bitstuffing_error_cnt_delta = str(int(bitstuffing_error_cnt_after,16) - int(bitstuffing_error_cnt_before,16))
-    timeout_error_cnt_delta = str(int(timeout_error_cnt_after,16) - int(timeout_error_cnt_before,16))
-    axi_strobe_error_cnt_delta = str(int(axi_strobe_error_cnt_after,16) - int(axi_strobe_error_cnt_before,16))
-    transaction_cnt_delta = str(int(transaction_cnt_after,16) - int(transaction_cnt_before,16))
+    crc_error_cnt_delta = int(crc_error_cnt_after,16) - int(crc_error_cnt_before,16)
+    packet_error_cnt_delta = int(packet_error_cnt_after,16) - int(packet_error_cnt_before,16)
+    bitstuffing_error_cnt_delta = int(bitstuffing_error_cnt_after,16) - int(bitstuffing_error_cnt_before,16)
+    timeout_error_cnt_delta = int(timeout_error_cnt_after,16) - int(timeout_error_cnt_before,16)
+    axi_strobe_error_cnt_delta = int(axi_strobe_error_cnt_after,16) - int(axi_strobe_error_cnt_before,16)
+    transaction_cnt_delta = int(transaction_cnt_after,16) - int(transaction_cnt_before,16)
 
-    f.write("| after | {0}  | {1} | {2} | {3} | {4} | {5} |\n".format(
+    outstring="| after | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
             crc_error_cnt_after,
             packet_error_cnt_after,
             bitstuffing_error_cnt_after,
             timeout_error_cnt_after,
             axi_strobe_error_cnt_after,
             transaction_cnt_after
-         ))
-    
-    print("| after | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
-            crc_error_cnt_after,
-            packet_error_cnt_after,
-            bitstuffing_error_cnt_after,
-            timeout_error_cnt_after,
-            axi_strobe_error_cnt_after,
-            transaction_cnt_after
-         ))
+         )
+    f.write(outstring)
+    f.write('\n')
+    print(outstring)
 
-    f.write("| delta | {0}  | {1} | {2} | {3} | {4} | {5} |\n".format(
+    outstring="| delta | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
             crc_error_cnt_delta,
             packet_error_cnt_delta,
             bitstuffing_error_cnt_delta,
             timeout_error_cnt_delta,
             axi_strobe_error_cnt_delta,
             transaction_cnt_delta
-         ))
-    
-    print("| delta | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
-            crc_error_cnt_delta,
-            packet_error_cnt_delta,
-            bitstuffing_error_cnt_delta,
-            timeout_error_cnt_delta,
-            axi_strobe_error_cnt_delta,
-            transaction_cnt_delta
-         ))
+         )
+    f.write(outstring)
+    f.write('\n')
+    print(outstring)
 
-    f.write(str(register_values)+"\n")
-    print(str(register_values))
+    outstring=str(register_values)
+    f.write(outstring)
+    f.write('\n')
+    print(outstring)

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+from reg_utils.reg_interface.common.reg_xml_parser import getNode, parseXML
+from reg_utils.reg_interface.common.reg_base_ops import readAddress
+from reg_utils.reg_interface.common.reg_base_ops import writeReg
+from reg_utils.reg_interface.common.print_utils import printRed
+from reg_utils.reg_interface.common.jtag import initJtagRegAddrs
+from reg_utils.reg_interface.common.reg_base_ops import *
+
+#from rw_reg import *
+#from mcs import *
+
+import time
+import array
+import struct
+import os
+import sys
+import socket
+
+import argparse
+
+if __name__ == '__main__':
+
+    from optparse import OptionParser
+    parser = OptionParser()
+    parser.add_option("-f", "--filename", type="str", dest="filename", help="Filename to which output information is written", default="repeated_reg_read.txt")
+
+    (options, args) = parser.parse_args()
+
+    if len(args) != 3:
+            print('Usage: repeated_reg_read.py <register_name> <number of times> <sleep time in microseconds>')
+            exit(os.EX_USAGE)
+
+    f = open(options.filename,"w")        
+            
+    parseXML()
+    
+    hostname = socket.gethostname()
+
+    if hostname == "eagle26":
+        print "This script is running on eagle26."
+        pass
+    else:
+       print "This script is not running on eagle26. rpc_connect(\"eagle26\") will be called."
+       rpc_connect("eagle26")   
+
+       HW_RW_REG 
+
+    writeReg(getNode("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET"),0x1)   
+
+    time.sleep(float(sys.argv[3])/float(1000000))
+    
+    crc_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT").real_address)
+    packet_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT").real_address)
+    bitstuffing_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.BITSTUFFING_ERROR_CNT").real_address)
+    timeout_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.TIMEOUT_ERROR_CNT").real_address)
+    axi_strobe_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT").real_address)
+    transaction_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT").real_address)
+    link_reset_before = readAddress(getNode("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET").real_address)
+
+    print >> f, "|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |"
+    print >> f, "|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |"
+    print >> f, "| before | "+crc_error_cnt_before+"    | "+packet_error_cnt_before+"       | "+bitstuffing_error_cnt_before+"            | "+timeout_error_cnt_before+"        | "+axi_strobe_error_cnt_before+"           | "+transaction_cnt_before+"      |"
+
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT = "+crc_error_cnt_before
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT = "+packet_error_cnt_before
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.BITSTUFFING_ERROR_CNT = "+ bitstuffing_error_cnt_before
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.TIMEOUT_ERROR_CNT = "+timeout_error_cnt_before
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT = "+axi_strobe_error_cnt_before
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT = "+transaction_cnt_before
+#    print "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET = "+link_reset_before
+    
+    node = getNode(sys.argv[1])
+
+    d = {}
+    
+    for i in range(0,int(sys.argv[2])):
+        value = readAddress(node.real_address)
+
+        if value in d.keys():
+            d[value] += 1
+        else:
+            d[value] = 1
+        
+        time.sleep(float(sys.argv[3])/float(1000000))
+
+    crc_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT").real_address)
+    packet_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT").real_address)
+    bitstuffing_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.BITSTUFFING_ERROR_CNT").real_address)
+    timeout_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.TIMEOUT_ERROR_CNT").real_address)
+    axi_strobe_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT").real_address)
+    transaction_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT").real_address)
+
+    print >> f, "| after  | "+crc_error_cnt_after+"    | "+packet_error_cnt_after+"       | "+bitstuffing_error_cnt_after+"            | "+timeout_error_cnt_after+"        | "+axi_strobe_error_cnt_after+"           | "+transaction_cnt_after+"      |"
+
+    print >> f, "| delta  | "+str(int(crc_error_cnt_after,16) - int(crc_error_cnt_before,16))+"             | "+str(int(packet_error_cnt_after,16) - int(packet_error_cnt_before,16))+"                | "+str(int(bitstuffing_error_cnt_after,16) - int(bitstuffing_error_cnt_before,16))+"                     | "+str(int(timeout_error_cnt_after,16) - int(timeout_error_cnt_before,16))+"                 | "+str(int(axi_strobe_error_cnt_after,16) - int(axi_strobe_error_cnt_before,16))+"               | "+str(int(transaction_cnt_after,16) - int(transaction_cnt_before,16))+"          |"    
+    
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT = "+crc_error_cnt_after
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT = "+packet_error_cnt_after
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.BITSTUFFING_ERROR_CNT = "+ bitstuffing_error_cnt_after
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.TIMEOUT_ERROR_CNT = "+timeout_error_cnt_after
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT = "+axi_strobe_error_cnt_after
+#    print "GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT = "+transaction_cnt_after
+#    print "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET = "+link_reset_after
+
+#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT = "+str(int(crc_error_cnt_after,16) - int(crc_error_cnt_before,16))
+#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT = "+str(int(packet_error_cnt_after,16) - int(packet_error_cnt_before,16))
+#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.BITSTUFFING_ERROR_CNT = "+ str(int(bitstuffing_error_cnt_after,16) - int(bitstuffing_error_cnt_before,16)) 
+#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.TIMEOUT_ERROR_CNT = "+str(int(timeout_error_cnt_after,16) - int(timeout_error_cnt_before,16))
+#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT = "+str(int(axi_strobe_error_cnt_after,16) - int(axi_strobe_error_cnt_before,16))
+#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT = "+str(int(transaction_cnt_after,16) - int(transaction_cnt_before,16))
+#    print "Delta GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET = "+str(int(link_reset_after,16) - int(link_reset_before,16))
+
+    print >> f, d
+    
+    #readAddress()

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -62,14 +62,6 @@ if __name__ == '__main__':
     print >> f, "|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |"
     print >> f, "| before | "+crc_error_cnt_before+"    | "+packet_error_cnt_before+"       | "+bitstuffing_error_cnt_before+"            | "+timeout_error_cnt_before+"        | "+axi_strobe_error_cnt_before+"           | "+transaction_cnt_before+"      |"
 
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT = "+crc_error_cnt_before
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT = "+packet_error_cnt_before
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.BITSTUFFING_ERROR_CNT = "+ bitstuffing_error_cnt_before
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.TIMEOUT_ERROR_CNT = "+timeout_error_cnt_before
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT = "+axi_strobe_error_cnt_before
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT = "+transaction_cnt_before
-#    print "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET = "+link_reset_before
-    
     node = getNode(sys.argv[1])
 
     d = {}
@@ -95,22 +87,6 @@ if __name__ == '__main__':
 
     print >> f, "| delta  | "+str(int(crc_error_cnt_after,16) - int(crc_error_cnt_before,16))+"             | "+str(int(packet_error_cnt_after,16) - int(packet_error_cnt_before,16))+"                | "+str(int(bitstuffing_error_cnt_after,16) - int(bitstuffing_error_cnt_before,16))+"                     | "+str(int(timeout_error_cnt_after,16) - int(timeout_error_cnt_before,16))+"                 | "+str(int(axi_strobe_error_cnt_after,16) - int(axi_strobe_error_cnt_before,16))+"               | "+str(int(transaction_cnt_after,16) - int(transaction_cnt_before,16))+"          |"    
     
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT = "+crc_error_cnt_after
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT = "+packet_error_cnt_after
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.BITSTUFFING_ERROR_CNT = "+ bitstuffing_error_cnt_after
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.TIMEOUT_ERROR_CNT = "+timeout_error_cnt_after
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT = "+axi_strobe_error_cnt_after
-#    print "GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT = "+transaction_cnt_after
-#    print "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET = "+link_reset_after
-
-#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT = "+str(int(crc_error_cnt_after,16) - int(crc_error_cnt_before,16))
-#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT = "+str(int(packet_error_cnt_after,16) - int(packet_error_cnt_before,16))
-#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.BITSTUFFING_ERROR_CNT = "+ str(int(bitstuffing_error_cnt_after,16) - int(bitstuffing_error_cnt_before,16)) 
-#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.TIMEOUT_ERROR_CNT = "+str(int(timeout_error_cnt_after,16) - int(timeout_error_cnt_before,16))
-#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT = "+str(int(axi_strobe_error_cnt_after,16) - int(axi_strobe_error_cnt_before,16))
-#    print "Delta GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT = "+str(int(transaction_cnt_after,16) - int(transaction_cnt_before,16))
-#    print "Delta GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET = "+str(int(link_reset_after,16) - int(link_reset_before,16))
-
     print >> f, d
     
     #readAddress()

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -82,15 +82,15 @@ if __name__ == '__main__':
 
     node = getNode(args.reg_name)
 
-    d = {}
+    register_values = {}
     
     for i in range(0,int(args.nreads)):
         value = readAddress(node.real_address)
 
-        if value in d.keys():
-            d[value] += 1
+        if value in register_values.keys():
+            register_values[value] += 1
         else:
-            d[value] = 1
+            register_values[value] = 1
         
         time.sleep(float(args.sleeptime)/float(1000000))
 
@@ -144,5 +144,5 @@ if __name__ == '__main__':
             transaction_cnt_delta
          ))
 
-    f.write(str(d)+"\n")
-    print(str(d))
+    f.write(str(register_values)+"\n")
+    print(str(register_values))

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -9,10 +9,6 @@ from reg_utils.reg_interface.common.reg_base_ops import *
 #from mcs import *
 
 import time
-import array
-import struct
-import os
-import sys
 import socket
 
 import argparse

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 from reg_utils.reg_interface.common.reg_xml_parser import getNode, parseXML
-from reg_utils.reg_interface.common.reg_base_ops import readAddress
-from reg_utils.reg_interface.common.reg_base_ops import writeReg
 from reg_utils.reg_interface.common.print_utils import printRed
 from reg_utils.reg_interface.common.jtag import initJtagRegAddrs
 from reg_utils.reg_interface.common.reg_base_ops import *

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -56,9 +56,29 @@ if __name__ == '__main__':
     transaction_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT").real_address)
     link_reset_before = readAddress(getNode("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET").real_address)
 
-    print >> f, "|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |"
-    print >> f, "|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |"
-    print >> f, "| before | "+crc_error_cnt_before+"    | "+packet_error_cnt_before+"       | "+bitstuffing_error_cnt_before+"            | "+timeout_error_cnt_before+"        | "+axi_strobe_error_cnt_before+"           | "+transaction_cnt_before+"      |"
+    f.write( "|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |\n")
+    print( "|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |")
+    
+    f.write("|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |\n")
+    print("|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |")
+
+    f.write("| before | {0}  | {1} | {2} | {3} | {4} | {5} |\n".format(
+            crc_error_cnt_before,
+            packet_error_cnt_before,
+            bitstuffing_error_cnt_before,
+            timeout_error_cnt_before,
+            axi_strobe_error_cnt_before,
+            transaction_cnt_before
+         ))
+
+    print("| before | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
+            crc_error_cnt_before,
+            packet_error_cnt_before,
+            bitstuffing_error_cnt_before,
+            timeout_error_cnt_before,
+            axi_strobe_error_cnt_before,
+            transaction_cnt_before
+         ))
 
     node = getNode(args.reg_name)
 
@@ -81,10 +101,48 @@ if __name__ == '__main__':
     axi_strobe_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.AXI_STROBE_ERROR_CNT").real_address)
     transaction_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT").real_address)
 
-    print >> f, "| after  | "+crc_error_cnt_after+"    | "+packet_error_cnt_after+"       | "+bitstuffing_error_cnt_after+"            | "+timeout_error_cnt_after+"        | "+axi_strobe_error_cnt_after+"           | "+transaction_cnt_after+"      |"
+    crc_error_cnt_delta = str(int(crc_error_cnt_after,16) - int(crc_error_cnt_before,16))
+    packet_error_cnt_delta = str(int(packet_error_cnt_after,16) - int(packet_error_cnt_before,16))
+    bitstuffing_error_cnt_delta = str(int(bitstuffing_error_cnt_after,16) - int(bitstuffing_error_cnt_before,16))
+    timeout_error_cnt_delta = str(int(timeout_error_cnt_after,16) - int(timeout_error_cnt_before,16))
+    axi_strobe_error_cnt_delta = str(int(axi_strobe_error_cnt_after,16) - int(axi_strobe_error_cnt_before,16))
+    transaction_cnt_delta = str(int(transaction_cnt_after,16) - int(transaction_cnt_before,16))
 
-    print >> f, "| delta  | "+str(int(crc_error_cnt_after,16) - int(crc_error_cnt_before,16))+"             | "+str(int(packet_error_cnt_after,16) - int(packet_error_cnt_before,16))+"                | "+str(int(bitstuffing_error_cnt_after,16) - int(bitstuffing_error_cnt_before,16))+"                     | "+str(int(timeout_error_cnt_after,16) - int(timeout_error_cnt_before,16))+"                 | "+str(int(axi_strobe_error_cnt_after,16) - int(axi_strobe_error_cnt_before,16))+"               | "+str(int(transaction_cnt_after,16) - int(transaction_cnt_before,16))+"          |"    
+    f.write("| after | {0}  | {1} | {2} | {3} | {4} | {5} |\n".format(
+            crc_error_cnt_after,
+            packet_error_cnt_after,
+            bitstuffing_error_cnt_after,
+            timeout_error_cnt_after,
+            axi_strobe_error_cnt_after,
+            transaction_cnt_after
+         ))
     
-    print >> f, d
+    print("| after | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
+            crc_error_cnt_after,
+            packet_error_cnt_after,
+            bitstuffing_error_cnt_after,
+            timeout_error_cnt_after,
+            axi_strobe_error_cnt_after,
+            transaction_cnt_after
+         ))
+
+    f.write("| delta | {0}  | {1} | {2} | {3} | {4} | {5} |\n".format(
+            crc_error_cnt_delta,
+            packet_error_cnt_delta,
+            bitstuffing_error_cnt_delta,
+            timeout_error_cnt_delta,
+            axi_strobe_error_cnt_delta,
+            transaction_cnt_delta
+         ))
     
-    #readAddress()
+    print("| delta | {0}  | {1} | {2} | {3} | {4} | {5} |".format(
+            crc_error_cnt_delta,
+            packet_error_cnt_delta,
+            bitstuffing_error_cnt_delta,
+            timeout_error_cnt_delta,
+            axi_strobe_error_cnt_delta,
+            transaction_cnt_delta
+         ))
+
+    f.write(str(d)+"\n")
+    print(str(d))


### PR DESCRIPTION
This script first issues a link reset, then reads a register, whose name is an input parameter, n times, where n is also an input parameter.

## Description
This script takes three mandatory input parameters: the name of the register to read, the number of times to read the register, and the sleep delay between the reads. There is also an optional output filename parameter. 

The script first issues a link reset, then performs the repeated reads, then reports the register values in the form of a python dictionary. Six slow control monitoring registers are also read at the beginning at the end, and their values, and the difference between their initial and final values, is reported in the form of a table.

Help output:
```
usage: repeated_reg_read.py [-h] [-f filename] [--card card]
                            reg_name nreads sleeptime

Arguments to supply to repeated_reg_read.py

positional arguments:
  reg_name              Name of the register to read
  nreads                Number of reads
  sleeptime             Amount of time to sleep in microseconds

optional arguments:
  -h, --help            show this help message and exit
  -f filename, --filename filename
                        Filename to which output information is written
  --card card           CTP7 hostname (has no effect if you are running on a
                        hostname that starts with eagle)
```

Example command:
```
repeated_reg_read.py GEM_AMC.OH.OH0.GEB.VFAT1.HW_CHIP_ID 10 250 -f my_filename.txt --card eagle64
```

Example output:
```
Open pickled address table if available  /opt/cmsgemos/etc/maps/amc_address_table_top.pickle...
This script is not running on an eagle machine. rpc_connect("eagle64") will be called.
Initial value to write: 1, register GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET
|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |
|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |
| before | 0x00000000  | 0x00000000 | 0x00000000 | 0x00000000 | 0x00000000 | 0x00000000 |
| after | 0x00000000  | 0x00000000 | 0x00000000 | 0x00000000 | 0x00640000 | 0x00640000 |
| delta | 0  | 0 | 0 | 0 | 6553600 | 6553600 |
{'0x000012e2': 10, '0x000112e2': 90}
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
We are trying to investigate an issue of bit slip i.e. a register which should contain a constant does not have a constant value based on tests using gem_reg.py

## How Has This Been Tested?
This script has been tested both on the GEM DAQ machines and on the ctp7.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
