### PR TITLE
add an option in gbt.py to set the phase

### DIFF
--- a/python/reg_interface/arm/gbt_utils.py
+++ b/python/reg_interface/arm/gbt_utils.py
@@ -93,12 +93,15 @@ def programGBT(ohSelect, gbtSelect, command):
         
         subheading('Setting the phase on OH%d GBT%d to %d' % (ohSelect, gbtSelect,phase))
 
-        for subReg in range(0, 3):
-            addr = GBT_ELINK_SAMPLE_PHASE_REGS[elink][subReg]
-            value = (regs[addr] & 0xf0) + phase
-            wReg(ADDR_IC_ADDR, addr)
-            wReg(ADDR_IC_WRITE_DATA, value)
-            wReg(ADDR_IC_EXEC_WRITE, 1)
+        initVfatRegAddrs()
+
+        for elink, vfat in V3B_GBT_ELINK_TO_VFAT[gbtSelect].items():
+            for subReg in range(0, 3):
+                addr = GBT_ELINK_SAMPLE_PHASE_REGS[elink][subReg]
+                value = phase
+                wReg(ADDR_IC_ADDR, addr)
+                wReg(ADDR_IC_WRITE_DATA, value)
+                wReg(ADDR_IC_EXEC_WRITE, 1)
         
     else:
         printRed("Unrecognized command '%s'" % command)

--- a/python/reg_interface/arm/gbt_utils.py
+++ b/python/reg_interface/arm/gbt_utils.py
@@ -84,6 +84,22 @@ def programGBT(ohSelect, gbtSelect, command):
         subheading('Destroying configuration of OH%d GBT%d' % (ohSelect, gbtSelect))
         destroyConfig()
 
+    elif command == 'set-phase':
+        if len(sys.argv) < 5:
+            print("For this command, you also need to provide a phase")
+            return
+
+        phase = int(sys.argv[4])
+        
+        subheading('Setting the phase on OH%d GBT%d' % (ohSelect, gbtSelect,phase))
+
+        for subReg in range(0, 3):
+            addr = GBT_ELINK_SAMPLE_PHASE_REGS[elink][subReg]
+            value = (regs[addr] & 0xf0) + phase
+            wReg(ADDR_IC_ADDR, addr)
+            wReg(ADDR_IC_WRITE_DATA, value)
+            wReg(ADDR_IC_EXEC_WRITE, 1)
+        
     else:
         printRed("Unrecognized command '%s'" % command)
         return

--- a/python/reg_interface/arm/gbt_utils.py
+++ b/python/reg_interface/arm/gbt_utils.py
@@ -91,7 +91,7 @@ def programGBT(ohSelect, gbtSelect, command):
 
         phase = int(sys.argv[4])
         
-        subheading('Setting the phase on OH%d GBT%d' % (ohSelect, gbtSelect,phase))
+        subheading('Setting the phase on OH%d GBT%d to %d' % (ohSelect, gbtSelect,phase))
 
         for subReg in range(0, 3):
             addr = GBT_ELINK_SAMPLE_PHASE_REGS[elink][subReg]

--- a/python/reg_interface/arm/gbt_utils.py
+++ b/python/reg_interface/arm/gbt_utils.py
@@ -85,24 +85,25 @@ def programGBT(ohSelect, gbtSelect, command):
         destroyConfig()
 
     elif command == 'set-phase':
-        if len(sys.argv) < 5:
-            print("For this command, you also need to provide a phase")
+        if len(sys.argv) < 6:
+            print("For this command, you also need to provide a vfat and a phase")
             return
 
-        phase = int(sys.argv[4])
+        vfat = int(sys.argv[4])
+        phase = int(sys.argv[5])
         
-        subheading('Setting the phase on OH%d GBT%d to %d' % (ohSelect, gbtSelect,phase))
+        subheading('Setting the phase on the elink associated with OH%d GBT%d VFAT%d to %d' % (ohSelect,gbtSelect,vfat,phase))
 
         initVfatRegAddrs()
 
-        for elink, vfat in V3B_GBT_ELINK_TO_VFAT[gbtSelect].items():
-            for subReg in range(0, 3):
-                addr = GBT_ELINK_SAMPLE_PHASE_REGS[elink][subReg]
-                value = phase
-                wReg(ADDR_IC_ADDR, addr)
-                wReg(ADDR_IC_WRITE_DATA, value)
-                wReg(ADDR_IC_EXEC_WRITE, 1)
-        
+        for elink in V3B_GBT_ELINK_TO_VFAT[gbtSelect].keys():
+            if V3B_GBT_ELINK_TO_VFAT[gbtSelect][elink] == vfat:
+                for subReg in range(0, 3):
+                    addr = GBT_ELINK_SAMPLE_PHASE_REGS[elink][subReg]
+                    wReg(ADDR_IC_ADDR, addr)
+                    wReg(ADDR_IC_WRITE_DATA, phase)
+                    wReg(ADDR_IC_EXEC_WRITE, 1)
+                break    
     else:
         printRed("Unrecognized command '%s'" % command)
         return

--- a/python/reg_interface/scripts/gbt.py
+++ b/python/reg_interface/scripts/gbt.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
         print('available commands:')
         print('  config <config_filename_txt>:   Configures the GBT with the given config file (must use the txt version of the config file, can be generated with the GBT programmer software)')
         print('  v3b-phase-scan <base_config_filename_txt>:   Configures the GBT with the given config file, and performs an elink phase scan while checking the VFAT communication for each phase')
-        print('  set-phase phase: Set the phase of a GBT')
+        print('  set-phase <phase>: Set the phase of a GBT')
         exit(os.EX_USAGE)
     else:
         ohSelect = int(sys.argv[1])

--- a/python/reg_interface/scripts/gbt.py
+++ b/python/reg_interface/scripts/gbt.py
@@ -15,6 +15,7 @@ if __name__ == '__main__':
         print('available commands:')
         print('  config <config_filename_txt>:   Configures the GBT with the given config file (must use the txt version of the config file, can be generated with the GBT programmer software)')
         print('  v3b-phase-scan <base_config_filename_txt>:   Configures the GBT with the given config file, and performs an elink phase scan while checking the VFAT communication for each phase')
+        print('  set-phase phase: Set the phase of a GBT')
         exit(os.EX_USAGE)
     else:
         ohSelect = int(sys.argv[1])

--- a/python/reg_interface/scripts/gbt.py
+++ b/python/reg_interface/scripts/gbt.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
         print('available commands:')
         print('  config <config_filename_txt>:   Configures the GBT with the given config file (must use the txt version of the config file, can be generated with the GBT programmer software)')
         print('  v3b-phase-scan <base_config_filename_txt>:   Configures the GBT with the given config file, and performs an elink phase scan while checking the VFAT communication for each phase')
-        print('  set-phase <phase>: Set the phase of a GBT')
+        print('  set-phase <vfat> <phase>: Set the phase of the elink associated with a specific vfat')
         exit(os.EX_USAGE)
     else:
         ohSelect = int(sys.argv[1])


### PR DESCRIPTION
Currently, gbt.py can run a phase scan, but cannot set a specific user-requested phase on the GBT.

## Description
A `set-phase <phase>` command has been added to gbt.py and the command has been implemented in gbt_utils.py 

Usage:
```
Usage: gbt.py <oh_num> <gbt_num> <command>
available commands:
  config <config_filename_txt>:   Configures the GBT with the given config file (must use the txt version of the config file, can be generated with the GBT programmer software)
  v3b-phase-scan <base_config_filename_txt>:   Configures the GBT with the given config file, and performs an elink phase scan while checking the VFAT communication for each phase
  set-phase <vfat> <phase>: Set the phase of the elink associated with a specific vfat
```
Example command: 
```
gbt.py 0 2 set-phase 10 5
```
Example output:
```
Open pickled address table if available  /opt/cmsgemos/etc/maps/amc_address_table_top.pickle...


>>>>>>> HELLO, I'M YOUR GBT CONTROLLER :) <<<<<<<

Initial value to write: 2, register GEM_AMC.SLOW_CONTROL.IC.GBTX_LINK_SELECT

---- Setting the phase on the elink associated with OH0 GBT2 VFAT10 to 5 ---- 

bye now..
```
There is no 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
I found increasing SYNC_ERR_CNTs for one VFAT on the coffin detector, which indicates a phase issue. I have taken a phase scan and found a phase value for which no error occurs, and I would like to be able to set this value on the gbt.

## How Has This Been Tested?
The slightly modified version of the script which uses rpc_connect was tested to set the phase on OH0 on eagle64.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
