### PR TITLE
In repeated_reg_read.py, set a lower limit on the allowed sleeptime

### DIFF
--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
 
     parser.add_argument('reg_name',metavar='reg_name',type=str,help='Name of the register to read')
     parser.add_argument('nreads',metavar='nreads',type=int,help='Number of reads')
-    parser.add_argument('sleeptime',metavar='sleeptime',type=float,help='Amount of time to sleep in microseconds')
+    parser.add_argument('sleeptime',metavar='sleeptime',type=float,help='Amount of time to sleep between reads, in microseconds. It should be >= 250 in order to avoid damage to the system.')
     parser.add_argument('-f','--filename',metavar='filename',type=str,help="Filename to which output information is written",default="repeated_reg_read.txt")
     parser.add_argument('--card',metavar='card',type=str,help='CTP7 hostname (has no effect if you are running on a hostname that starts with eagle)',default="eagle26")
 
@@ -69,6 +69,11 @@ if __name__ == '__main__':
     node = getNode(args.reg_name)
 
     register_values = {}
+
+    sleeptime = args.sleeptime
+    if sleeptime < 250.:
+        print("Warning, sleeptime will be increased to 250 microseconds")
+        sleeptime = 250.
     
     for i in range(0,int(args.nreads)):
         value = readAddress(node.real_address)
@@ -78,7 +83,7 @@ if __name__ == '__main__':
         else:
             register_values[value] = 1
         
-        time.sleep(args.sleeptime/1000000.)
+        time.sleep(sleeptime/1000000.)
 
     crc_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT").real_address)
     packet_error_cnt_after = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT").real_address)

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -34,7 +34,12 @@ if __name__ == '__main__':
 
     writeReg(getNode("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET"),0x1)   
 
-    time.sleep(args.sleeptime/1000000.)
+    sleeptime = args.sleeptime
+    if sleeptime < 250.:
+        print("Warning, sleeptime will be increased to 250 microseconds")
+        sleeptime = 250.
+    
+    time.sleep(sleeptime/1000000.)
     
     crc_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.CRC_ERROR_CNT").real_address)
     packet_error_cnt_before = readAddress(getNode("GEM_AMC.SLOW_CONTROL.VFAT3.PACKET_ERROR_CNT").real_address)
@@ -70,11 +75,6 @@ if __name__ == '__main__':
 
     register_values = {}
 
-    sleeptime = args.sleeptime
-    if sleeptime < 250.:
-        print("Warning, sleeptime will be increased to 250 microseconds")
-        sleeptime = 250.
-    
     for i in range(0,int(args.nreads)):
         value = readAddress(node.real_address)
 

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -13,9 +13,9 @@ if __name__ == '__main__':
 
     parser.add_argument('reg_name',metavar='reg_name',type=str,help='Name of the register to read')
     parser.add_argument('nreads',metavar='nreads',type=int,help='Number of reads')
-    parser.add_argument('sleeptime',metavar='sleeptime',type=float,help='Amount of time to sleep between reads, in microseconds. It should be >= 250 in order to avoid damage to the system.')
+    parser.add_argument('sleeptime',metavar='sleeptime',type=float,help='Amount of time to sleep between reads, in microseconds. It should be >= 250 in order to avoid overlapping transactions on the AXI bus.')
     parser.add_argument('-f','--filename',metavar='filename',type=str,help="Filename to which output information is written",default="repeated_reg_read.txt")
-    parser.add_argument('--card',metavar='card',type=str,help='CTP7 hostname (has no effect if you are running on a hostname that starts with eagle)',default="eagle26")
+    parser.add_argument('-c','--cardName',metavar='card',type=str,help='CTP7 hostname (has no effect if you are running on a hostname that starts with eagle)',default="eagle26")
 
     args = parser.parse_args()
 

--- a/python/reg_interface/scripts/repeated_reg_read.py
+++ b/python/reg_interface/scripts/repeated_reg_read.py
@@ -29,8 +29,8 @@ if __name__ == '__main__':
         print("This script is running on"+str(hostname)+".")
         pass
     else:
-       print("This script is not running on an eagle machine. rpc_connect(\""+str(args.card)+"\") will be called.")
-       rpc_connect(args.card)   
+       print("This script is not running on an eagle machine. rpc_connect(\""+str(args.cardName)+"\") will be called.")
+       rpc_connect(args.cardName)   
 
     writeReg(getNode("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET"),0x1)   
 


### PR DESCRIPTION
@bdorney recommended a lower limit of 250 microseconds in this mattermost post:
https://mattermost.web.cern.ch/cms-gem-daq/pl/japgeibh6fdub8j78f9dfmj85c

## Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This change was requested in https://github.com/AndrewLevin/sw_utils/pull/1#pullrequestreview-173962680

## How Has This Been Tested?
Yes, the terminal output from running 
```
python repeated_reg_read.py GEM_AMC.OH.OH0.GEB.VFAT1.HW_CHIP_ID 100 249 -f my_filename.txt --cardName eagle64  
```
is
```
Open pickled address table if available  /opt/cmsgemos/etc/maps/amc_address_table_top.pickle...
This script is not running on an eagle machine. rpc_connect("eagle64") will be called.
Initial value to write: 1, register GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET
|        | CRC_ERROR_CNT | PACKET_ERROR_CNT | BITSTUFFING_ERROR_CNT | TIMEOUT_ERROR_CNT | AXI_STROBE_ERROR_CNT | TRANSACTION_CNT |
|:------ | :------------ | :--------------- | :-------------------- | :---------------- | :------------------- | :-------------- |
| before | 0x00000000  | 0x00000000 | 0x00000000 | 0x00000000 | 0x00000000 | 0x00000000 |
Warning, sleeptime will be increased to 250 microseconds
| after | 0x00000000  | 0x00000000 | 0x00000000 | 0x00000000 | 0x00640000 | 0x00640000 |
| delta | 0  | 0 | 0 | 0 | 6553600 | 6553600 |
{'0x000012e2': 8, '0x000112e2': 92}
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
