### PR TITLE
Fix typo in makefile

### DIFF
--- a/rwreg/x86_64/Makefile
+++ b/rwreg/x86_64/Makefile
@@ -68,4 +68,6 @@ clean: cleanrpm
 	-rm -rf $(PackageDir)
 
 cleandoc: 
-	-rm-rf doc/html  doc/latex  doc/xml
+	-rm -rf doc/html
+	-rm -rf doc/latex
+	-rm -rf doc/xml


### PR DESCRIPTION
Fixes typo in `cleandoc` target